### PR TITLE
fix(aegis): :sparkles: subtract energy for erroring agents

### DIFF
--- a/src/_aegis/constants.py
+++ b/src/_aegis/constants.py
@@ -25,6 +25,7 @@ class Constants:
     PREDICTION_ENERGY_COST: int = 1
     MOVE_ENERGY_COST: int = 1
     DRONE_SCAN_ENERGY_COST: int = 2
+    ENERGY_PENALTY_FOR_ERRORS: int = -10
 
     # Directives constants
     MAX_DIRECTIVES: int = 5

--- a/src/aegis/stub.py
+++ b/src/aegis/stub.py
@@ -7,6 +7,8 @@ Do not modify manually.
 # pyright: reportReturnType=false
 # pyright: reportUnusedImport=false
 # pyright: reportUnusedParameter=false
+import numpy as np
+from numpy.typing import NDArray
 
 from . import (
     CellInfo,
@@ -66,6 +68,17 @@ def recharge() -> None:
     """
 
 
+def predict(surv_id: int, label: np.int32) -> None:
+    """
+    Submit a prediction.
+
+    Args:
+        surv_id (int): The unique ID of the survivor.
+        label (int): The predicted label/classification for the survivor.
+
+    """
+
+
 def on_map(loc: Location) -> bool:
     """
     Check whether a location is within the bounds of the world.
@@ -113,6 +126,17 @@ def log(*args: object) -> None:
 
     Args:
         *args: The message to log.
+
+    """
+
+
+def read_pending_predictions() -> list[tuple[int, NDArray[np.uint8], NDArray[np.int32]]]:
+    """
+    Retrieve the list of pending predictions stored by the agent's team.
+
+    Returns:
+        list[tuple[int, NDArray[np.uint8], NDArray[np.int32]]]: A list of tuples representing pending survivor predictions (surv_id, image_to_predict, all_unique_labels).
+            Returns an empty list if no pending predictions are available.
 
     """
 


### PR DESCRIPTION
Agents that throw errors during turns now lose energy each turn they error, instead of aegis letting them slide. Error message is also hidden unless --debug flag is used.

## Description

infrequent errors are permitted, but erroring every turn will kill your agent, which is a better system

## Related Issue(s)

resolves #259 

## Screenshots

<img width="674" height="212" alt="image" src="https://github.com/user-attachments/assets/7ef485b0-bd58-4b1d-9688-d997e586470e" />

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/CPSC-383/aegis/blob/dev/CONTRIBUTING.md) guidelines.
