### PR TITLE
fix(client): add custom scrollbar styles to worlds scrollbar

### DIFF
--- a/client/src/components/ui/multiselect.tsx
+++ b/client/src/components/ui/multiselect.tsx
@@ -75,7 +75,7 @@ export function MultiSelect({
         </div>
       </div>
 
-      <div className="max-h-48 overflow-y-auto border border-input rounded-md bg-background">
+      <div className="max-h-48 overflow-y-auto border border-input rounded-md bg-background scrollbar">
         {options.length === 0 ? (
           <div className="flex items-center justify-center py-8 text-muted-foreground text-sm">
             No worlds available


### PR DESCRIPTION
## Description

change from the default scrollbar to scrollbar style used in rest of client

## Related Issue(s)

## Screenshots

<img width="277" height="690" alt="image" src="https://github.com/user-attachments/assets/cc3da634-674a-4120-bc3f-ae2273abfc28" />

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/CPSC-383/aegis/blob/main/CONTRIBUTING.md) guidelines.
